### PR TITLE
fix: Move build dependencies to main dependencies for Netlify compati…

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,28 +14,28 @@
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.15.13",
     "@mui/material": "^5.15.13",
+    "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.18",
     "framer-motion": "^11.0.14",
     "lucide-react": "^0.487.0",
     "nodemailer": "^6.9.12",
+    "postcss": "^8.4.35",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^5.0.1",
     "react-intersection-observer": "^9.8.1",
     "react-router-dom": "^6.22.3",
     "react-scroll": "^1.9.0",
-    "styled-components": "^6.1.8"
+    "styled-components": "^6.1.8",
+    "tailwindcss": "^3.4.1",
+    "vite": "^5.1.7"
   },
   "devDependencies": {
     "@types/react": "^18.2.64",
     "@types/react-dom": "^18.2.21",
-    "@vitejs/plugin-react": "^4.2.1",
-    "autoprefixer": "^10.4.18",
     "eslint": "^8.57.0",
     "eslint-plugin-react": "^7.34.0",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-react-refresh": "^0.4.5",
-    "postcss": "^8.4.35",
-    "tailwindcss": "^3.4.1",
-    "vite": "^5.1.7"
+    "eslint-plugin-react-refresh": "^0.4.5"
   }
 }


### PR DESCRIPTION
…bility

- Move vite, @vitejs/plugin-react, autoprefixer, postcss, and tailwindcss to dependencies
- Ensures build tools are available during Netlify deployment
- Fixes 'vite: not found' error during production builds
- Keeps only linting tools in devDependencies